### PR TITLE
feat: 動的ワークスペース切り替え機能を実装

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -329,7 +329,14 @@ class DiscordClaudeBot {
   }
 
   private getWorkspaceForChannel(channel: GuildTextBasedChannel): string {
-    const channelName = channel.name;
+    // If we're in a thread, get the parent channel name
+    let channelName: string;
+    if (channel.isThread()) {
+      channelName = channel.parent?.name || channel.name;
+      console.log(`📍 Thread detected. Using parent channel: ${channelName}`);
+    } else {
+      channelName = channel.name;
+    }
     
     // Check if channel name starts with 'dev_'
     if (channelName.startsWith('dev_')) {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -29,7 +29,7 @@ class DiscordClaudeBot {
 
     // Initialize base working directory from environment variable or default
     this.baseWorkingDir = process.env.CLAUDE_WORK_DIR || path.join(process.cwd(), 'working_dir');
-    this.claude = new ClaudeSDKWrapper(this.baseWorkingDir);
+    this.claude = new ClaudeSDKWrapper();
 
     this.setupEventHandlers();
   }
@@ -105,11 +105,8 @@ class DiscordClaudeBot {
         return;
       }
       
-      // Update Claude SDK wrapper's working directory if it changed
-      if (this.claude.getWorkingDirectory() !== workspacePath) {
-        this.claude.setWorkingDirectory(workspacePath);
-        console.log(`🔄 Workspace switched to: ${workspacePath}`);
-      }
+      // Working directory will be passed directly to executeCommandWithStreaming
+      console.log(`🔄 Using workspace: ${workspacePath}`);
 
       // Check if we're in a thread and have an existing session
       const threadId = isInThread ? channel.id : null;
@@ -184,7 +181,7 @@ class DiscordClaudeBot {
         }
       };
       
-      const result = await this.claude.executeCommandWithStreaming(finalPrompt, existingSessionId, callbacks);
+      const result = await this.claude.executeCommandWithStreaming(finalPrompt, existingSessionId, callbacks, workspacePath);
       
       // Store session ID for future use in this thread
       if (result.sessionId) {

--- a/src/claude-sdk-wrapper.ts
+++ b/src/claude-sdk-wrapper.ts
@@ -19,20 +19,18 @@ export interface StreamCallback {
 }
 
 export class ClaudeSDKWrapper {
-  private workingDir: string;
-
-  constructor(workingDir: string = process.cwd()) {
-    this.workingDir = workingDir;
+  constructor() {
+    // ステートレスなクラスに変更 - working dirは引数で受け取る
   }
 
-  async executeCommand(prompt: string, sessionId?: string): Promise<ClaudeResult> {
+  async executeCommand(prompt: string, sessionId?: string, workingDir: string = process.cwd()): Promise<ClaudeResult> {
     try {
       const messages: SDKMessage[] = [];
       const abortController = new AbortController();
 
       // Configure options based on environment variables
       const options: Options = {
-        cwd: this.workingDir,
+        cwd: workingDir,
         maxTurns: 10 // Default reasonable limit
       };
 
@@ -106,14 +104,14 @@ export class ClaudeSDKWrapper {
     }
   }
 
-  async executeCommandWithStreaming(prompt: string, sessionId?: string, callbacks?: StreamCallback): Promise<ClaudeResult> {
+  async executeCommandWithStreaming(prompt: string, sessionId?: string, callbacks?: StreamCallback, workingDir: string = process.cwd()): Promise<ClaudeResult> {
     try {
 
       const messages: SDKMessage[] = [];
       const abortController = new AbortController();
 
       const options: Options = {
-        cwd: this.workingDir,
+        cwd: workingDir,
         maxTurns: 10
       };
 
@@ -239,11 +237,4 @@ export class ClaudeSDKWrapper {
     }
   }
 
-  setWorkingDirectory(dir: string): void {
-    this.workingDir = dir;
-  }
-
-  getWorkingDirectory(): string {
-    return this.workingDir;
-  }
 }


### PR DESCRIPTION
## Summary
- チャンネル名が `dev_` で始まる場合、対応するプロジェクトディレクトリを自動的に使用する動的ワークスペース機能を実装
- 環境変数 `CLAUDE_WORK_DIR` によるベースワークスペースの設定をサポート
- ワークスペースディレクトリの検証とエラーハンドリングを追加

## 実装内容
- `getWorkspaceForChannel()`: チャンネル名に基づくワークスペース決定
- `validateWorkspace()`: ワークスペースディレクトリの検証
- 動的ワークスペース切り替えのログ出力
- 日本語エラーメッセージとヒント表示

## 使用例
- 通常チャンネル (`general`): ベース `$CLAUDE_WORK_DIR` を使用
- 開発チャンネル (`dev_sample_repo`): `$CLAUDE_WORK_DIR/sample_repo/` を使用

## Test plan
- [x] 通常チャンネルでのワークスペース動作確認
- [x] `dev_` プレフィックス付きチャンネルでの動作確認
- [ ] 存在しないディレクトリの場合のエラーハンドリング確認
- [x] 環境変数 `CLAUDE_WORK_DIR` の設定確認

🤖 Generated with [Claude Code](https://claude.ai/code)